### PR TITLE
fix the issue that couldn't fetch python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:14.04
-RUN apt-get install -y python
+RUN apt-get update && apt-get install -y python2.7
 ADD . /src
 WORKDIR /src
-CMD ["python", "sleep.py", "10"]
+CMD ["python2.7", "sleep.py", "10"]


### PR DESCRIPTION
Hi @carol-hsu 

I found this example that doesn't work due to get below error.
Please merge to cookbook repo.

> Step 1/5 : FROM ubuntu:14.04
14.04: Pulling from library/ubuntu
Digest: sha256:f0cc0848fdadb4ae7341028a21f894df7cc2ab56e2bfe162850cbd602234d9a4
Status: Downloaded newer image for ubuntu:14.04
 ---> 02a63d8b2bfa
Step 2/5 : RUN apt-get install -y python
 ---> Running in 4cebb342f502
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python
The command '/bin/sh -c apt-get install -y python' returned a non-zero code: 100

> $ docker run -it a195d726cfa9
docker: Error response from daemon: OCI runtime create failed: container_linux.go:296: starting container process caused "exec: \"python\": executable file not found in $PATH": unknown.
$ docker run -it a195d726cfa9 /bin/bash
root@dc3f8ab0712d:/src# which python
root@dc3f8ab0712d:/src# python
python2.7   python3     python3.4   python3.4m  python3m    

